### PR TITLE
docker: fix install oracle-jdk11-installer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,9 +49,9 @@ RUN \
   apt-get install -y software-properties-common && \
   add-apt-repository -y ppa:linuxuprising/java && \
   apt-get update && \
-  apt-get install -y oracle-java11-installer && \
+  apt-get install -y oracle-java11-installer-local && \
   rm -rf /var/lib/apt/lists/* && \
-  rm -rf /var/cache/oracle-jdk11-installer
+  rm -rf /var/cache/oracle-jdk11-installer-local
 
 # Set the locale, else yocto will complain
 RUN locale-gen en_US.UTF-8


### PR DESCRIPTION
petalinux need jdk.

Package oracle-java11-installer is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
oracle-java11-installer-local

Signed-off-by: Yen-Chin Lee <coldnew.tw@gmail.com>